### PR TITLE
Add GitHub issue templates for roadmap items

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-add-persistent-storage.md
+++ b/.github/ISSUE_TEMPLATE/01-add-persistent-storage.md
@@ -1,0 +1,20 @@
+---
+name: Add persistent storage (SQLite + ORM)
+about: Replace in-memory activities with a persistent database
+---
+
+**Goal**
+
+Replace in-memory `activities` with a persistent database to survive restarts and support relations (users, clubs, events).
+
+**Tasks**
+
+- Add SQLite and an ORM (SQLModel or SQLAlchemy + Pydantic models).
+- Create migrations or a simple init script.
+- Migrate `activities` data to a database model with fields: id, name, description, schedule, max_participants.
+- Update endpoints to use the database.
+
+**Acceptance criteria**
+
+- Data persists after server restart.
+- Existing endpoints `/activities`, signup/unregister work against DB.

--- a/.github/ISSUE_TEMPLATE/02-add-user-authentication.md
+++ b/.github/ISSUE_TEMPLATE/02-add-user-authentication.md
@@ -1,0 +1,19 @@
+---
+name: Add user model and authentication (OAuth2 / JWT)
+about: Introduce user accounts and protect actions with authentication
+---
+
+**Goal**
+
+Introduce user accounts and protect actions with authentication.
+
+**Tasks**
+
+- Create `User` model (email, name, password hash, role).
+- Implement registration (`POST /users`) and token-based login (`POST /token`) using FastAPI OAuth2/JWT.
+- Protect signup/unregister and new endpoints with dependency injection for `current_user`.
+
+**Acceptance criteria**
+
+- Users can register and receive a token.
+- Protected endpoints require valid token.

--- a/.github/ISSUE_TEMPLATE/03-user-profiles-ui.md
+++ b/.github/ISSUE_TEMPLATE/03-user-profiles-ui.md
@@ -1,0 +1,17 @@
+---
+name: Add user profile endpoints and UI
+about: Allow users to view and edit their profile information
+---
+
+**Goal**
+
+Allow users to view and edit their profile information.
+
+**Tasks**
+
+- Add endpoints: `GET /users/{id}`, `PUT /users/{id}` (authenticated).
+- Add a profile page in the static UI (profile view + edit form).
+
+**Acceptance criteria**
+
+- Profile data saved in DB and editable by owner.

--- a/.github/ISSUE_TEMPLATE/04-events-rsvp.md
+++ b/.github/ISSUE_TEMPLATE/04-events-rsvp.md
@@ -1,0 +1,18 @@
+---
+name: Add event creation & RSVP endpoints
+about: Support creating events (club and non-club), listing by date, and RSVPs
+---
+
+**Goal**
+
+Support creating events (club and non-club), listing by date, and RSVPs.
+
+**Tasks**
+
+- Add `Event` model with organizer_id, title, description, start_time, end_time, location, capacity.
+- Endpoints: `POST /events`, `GET /events`, `GET /events/{id}`, `POST /events/{id}/rsvp`, `DELETE /events/{id}/rsvp`.
+- Update UI to list events and allow RSVPing.
+
+**Acceptance criteria**
+
+- Events can be created and RSVPed; capacity enforced.

--- a/.github/ISSUE_TEMPLATE/05-membership-roles.md
+++ b/.github/ISSUE_TEMPLATE/05-membership-roles.md
@@ -1,0 +1,17 @@
+---
+name: Add club membership roles and approval workflow
+about: Support roles (member, admin) and join-request approval for clubs
+---
+
+**Goal**
+
+Support roles (member, admin) and join-request approval for clubs.
+
+**Tasks**
+
+- Add membership model with role and status (pending/approved).
+- Endpoints for join requests, approval by admins, and role management.
+
+**Acceptance criteria**
+
+- Admins can approve join requests; roles enforced on protected actions.

--- a/.github/ISSUE_TEMPLATE/06-extract-pydantic-models.md
+++ b/.github/ISSUE_TEMPLATE/06-extract-pydantic-models.md
@@ -1,0 +1,17 @@
+---
+name: Extract Pydantic models and utilities
+about: Cleanly separate data models and helper utilities for maintainability
+---
+
+**Goal**
+
+Cleanly separate data models and helper utilities for maintainability.
+
+**Tasks**
+
+- Move data structures into `models.py` / package with Pydantic models.
+- Add utility module for UUIDs, config loading, and common responses.
+
+**Acceptance criteria**
+
+- Clear separation of concerns and reusability across endpoints.

--- a/.github/ISSUE_TEMPLATE/07-ui-spa-or-mobile.md
+++ b/.github/ISSUE_TEMPLATE/07-ui-spa-or-mobile.md
@@ -1,0 +1,17 @@
+---
+name: Improve web UI to multi-page SPA or add mobile client plan
+about: Expand the static UI into a multi-screen app or plan a mobile client
+---
+
+**Goal**
+
+Expand the static UI into a multi-screen app or plan a mobile client.
+
+**Tasks**
+
+- Convert static frontend into a small SPA (React/Vue) with routes for Activities, Events, Profile, Admin.
+- Or produce an API spec (OpenAPI) and a plan for a mobile client.
+
+**Acceptance criteria**
+
+- UI supports profile, activity details, and event pages.

--- a/.github/ISSUE_TEMPLATE/08-tests-ci.md
+++ b/.github/ISSUE_TEMPLATE/08-tests-ci.md
@@ -1,0 +1,17 @@
+---
+name: Add tests and CI
+about: Add automated tests and CI to maintain reliability
+---
+
+**Goal**
+
+Add automated tests and CI to maintain reliability.
+
+**Tasks**
+
+- Add pytest tests for endpoints and core logic.
+- Add GitHub Actions workflow to run tests on push/PR.
+
+**Acceptance criteria**
+
+- Tests run in CI and fail on regressions.


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/` files for planned work: persistent storage, auth, profiles, events, membership roles, models, UI improvements, and CI/tests. These templates make it easy to open issues or use GitHub's new-issue UI.